### PR TITLE
Update iframe height and clean up script tags

### DIFF
--- a/Hash.html
+++ b/Hash.html
@@ -578,7 +578,7 @@
   atOptions = {
   	'key' : '9ab4671e6336ce914f320b0fd175fe10',
   	'format' : 'iframe',
-  	'height' : 50,
+  	'height' : 80,
   	'width' : 320,
   	'params' : {}
   };
@@ -629,19 +629,7 @@
                 </button>
 
                 
-<script type="text/javascript">
-  atOptions = {
-  	'key' : '9ab4671e6336ce914f320b0fd175fe10',
-  	'format' : 'iframe',
-  	'height' : 50,
-  	'width' : 320,
-  	'params' : {}
-  };
-</script>
-<script
-  type="text/javascript"
-  src="//www.highperformanceformat.com/9ab4671e6336ce914f320b0fd175fe10/invoke.js"
-></script>
+
                 
                 <div class="security-note">
                     <i class="fas fa-shield-alt"></i>


### PR DESCRIPTION
Increased the height of the iframe from 50 to 80 pixels and removed redundant script tags.